### PR TITLE
Fix `PANIC=....` message in logs and improve dev XP

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/oklog/ulid/v2 v2.1.0
+	github.com/prometheus/common v0.63.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.12.0
@@ -50,7 +51,6 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.21.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/tailscale/hujson v0.0.0-20250226034555-ec1d1c113d33 // indirect

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -198,6 +198,9 @@ func (c *RunCmd) kubernetesReconcilationLoop(ctx context.Context) error {
 		Named(c.ctrlName).
 		For(&corev1.Secret{}).
 		WithLogConstructor(func(r *reconcile.Request) logr.Logger {
+			if r == nil {
+				return log
+			}
 			return log.WithValues("secret", r)
 		}).
 		Complete(c.reconciler)

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -102,16 +102,17 @@ func (c *RunCmd) Run(cli *kong.Context) error {
 	c.ctrlName = cli.Model.Name
 
 	// Initialize the logger and context
-	log := zap.New(
+	zopts := []zap.Opts{
 		zap.UseFlagOptions(&zap.Options{
 			TimeEncoder: zapcore.ISO8601TimeEncoder,
 		}),
 		zap.Level(c.Log.Verbosity),
 		zap.Encoder(c.Log.Format),
-	)
-	if c.Log.Development {
-		log = zap.New(zap.UseDevMode(true))
 	}
+	if c.Log.Development {
+		zopts = []zap.Opts{zap.UseDevMode(true), zap.Level(zapcore.Level(-127))}
+	}
+	log := zap.New(zopts...)
 	ctrllog.SetLogger(log)
 	ctx := ctrllog.IntoContext(signals.SetupSignalHandler(), log)
 


### PR DESCRIPTION
This pull request includes several changes to the `go.mod` file and improvements to the logging setup in the `internal/controller/controller.go` file. The most important changes are:

Dependency updates in `go.mod`:

* Added `github.com/prometheus/common v0.63.0` to the list of required dependencies.
* Removed the indirect requirement for `github.com/prometheus/common v0.63.0`.

Logging setup improvements in `internal/controller/controller.go`:

* Refactored the logger initialization to use a slice of `zap.Opts` for better configuration and readability.
* Added a nil check for the `reconcile.Request` object in the `WithLogConstructor` method to ensure the logger is correctly initialized even when the request is nil.