### PR TITLE
Create the secret where the controller is setup for

### DIFF
--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -148,8 +148,8 @@ func (r reconciler) CreateDeviceSecret(ctx context.Context, namespacedName types
 
 	secret := corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      device.Name,
-			Namespace: "default",
+			Name:      namespacedName.Name,
+			Namespace: namespacedName.Namespace,
 			Annotations: map[string]string{
 				AnnotationDeviceID:       device.NodeID,
 				AnnotationDeviceHostname: device.Hostname,

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -1,3 +1,5 @@
+/* trunk-ignore-all(golangci-lint/lll): Don't care about lll here */
+/* trunk-ignore(golangci-lint/testpackage): Need to access to the internal reconciler type */
 package reconciler
 
 import (
@@ -55,14 +57,14 @@ func (suite *ReconcilerSuite) TestReconcile_NewDevice() {
 
 	res, err := suite.reconciler.Reconcile(
 		context.TODO(),
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}},
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}},
 	)
 	suite.Require().NoError(err)
 	suite.Equal(reconcile.Result{}, res)
 
 	// Check the device secret freshly created.
 	var secret corev1.Secret
-	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}, &secret)
+	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}, &secret)
 	suite.Require().NoError(err)
 
 	suite.Equal("fake-device-id", secret.Annotations[AnnotationDeviceID])
@@ -84,7 +86,7 @@ func (suite *ReconcilerSuite) TestReconcile_ExistingDevice() {
 	err := suite.kubernetesMock.Create(context.TODO(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "A.fake.ts.net",
-			Namespace: "default",
+			Namespace: "argocd",
 			Annotations: map[string]string{
 				AnnotationDeviceID:       "fake-device-id",
 				AnnotationDeviceHostname: "A",
@@ -122,14 +124,14 @@ func (suite *ReconcilerSuite) TestReconcile_ExistingDevice() {
 
 	res, err := suite.reconciler.Reconcile(
 		context.TODO(),
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}},
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}},
 	)
 	suite.Require().NoError(err)
 	suite.Equal(reconcile.Result{}, res)
 
 	// Check the device secret freshly created.
 	var secret corev1.Secret
-	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}, &secret)
+	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}, &secret)
 	suite.Require().NoError(err)
 
 	suite.Equal("fake-device-id", secret.Annotations[AnnotationDeviceID])
@@ -151,7 +153,7 @@ func (suite *ReconcilerSuite) TestReconcile_UpdatedExistingDevice() {
 	err := suite.kubernetesMock.Create(context.TODO(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "A.fake.ts.net",
-			Namespace: "default",
+			Namespace: "argocd",
 			Annotations: map[string]string{
 				"existing-annotation": "true",
 				AnnotationDeviceID:    "not-fake-device-id",
@@ -184,14 +186,14 @@ func (suite *ReconcilerSuite) TestReconcile_UpdatedExistingDevice() {
 
 	res, err := suite.reconciler.Reconcile(
 		context.TODO(),
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}},
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}},
 	)
 	suite.Require().NoError(err)
 	suite.Equal(reconcile.Result{}, res)
 
 	// Check the device secret freshly created.
 	var secret corev1.Secret
-	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}, &secret)
+	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}, &secret)
 	suite.Require().NoError(err)
 
 	// Note: The existing annotation and label are preserved if they are not one of the device metadata.
@@ -219,7 +221,7 @@ func (suite *ReconcilerSuite) TestReconcile_DeletedDevice() {
 	err := suite.kubernetesMock.Create(context.TODO(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "A.fake.ts.net",
-			Namespace:   "default",
+			Namespace:   "argocd",
 			Annotations: map[string]string{},
 		},
 	})
@@ -236,14 +238,14 @@ func (suite *ReconcilerSuite) TestReconcile_DeletedDevice() {
 
 	res, err := suite.reconciler.Reconcile(
 		context.TODO(),
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}},
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}},
 	)
 	suite.Require().NoError(err)
 	suite.Equal(reconcile.Result{}, res)
 
 	// Check the device secret freshly created.
 	var secret corev1.Secret
-	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}, &secret)
+	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}, &secret)
 	suite.Error(err)
 	suite.True(errors.IsNotFound(err))
 }
@@ -260,14 +262,14 @@ func (suite *ReconcilerSuite) TestReconcile_DeleteNonExistingDevice() {
 
 	res, err := suite.reconciler.Reconcile(
 		context.TODO(),
-		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}},
+		reconcile.Request{NamespacedName: types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}},
 	)
 	suite.Require().NoError(err)
 	suite.Equal(reconcile.Result{}, res)
 
 	// Check the device secret freshly created.
 	var secret corev1.Secret
-	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}, &secret)
+	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}, &secret)
 	suite.Error(err)
 	suite.True(errors.IsNotFound(err))
 }
@@ -276,7 +278,7 @@ func (suite *ReconcilerSuite) TestCreateSecretDevice() {
 	// Create a new device secret.
 	err := suite.reconciler.CreateDeviceSecret(
 		context.TODO(),
-		types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"},
+		types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"},
 		tailscale.Device{
 			Name:          "A.fake.ts.net",
 			Hostname:      "A",
@@ -290,7 +292,7 @@ func (suite *ReconcilerSuite) TestCreateSecretDevice() {
 
 	// Check the device secret.
 	var secret corev1.Secret
-	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}, &secret)
+	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}, &secret)
 	suite.Require().NoError(err)
 
 	suite.Equal("fake-device-id", secret.Annotations[AnnotationDeviceID])
@@ -312,7 +314,7 @@ func (suite *ReconcilerSuite) TestUpdateSecretDevice() {
 	err := suite.kubernetesMock.Create(context.TODO(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "A.fake.ts.net",
-			Namespace: "default",
+			Namespace: "argocd",
 			Annotations: map[string]string{
 				"existing-annotation": "true",
 				AnnotationDeviceID:    "initial-device-id",
@@ -330,7 +332,7 @@ func (suite *ReconcilerSuite) TestUpdateSecretDevice() {
 	// Update the device secret.
 	err = suite.reconciler.UpdateDeviceSecret(
 		context.TODO(),
-		types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"},
+		types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"},
 		tailscale.Device{
 			Name:          "A.fake.ts.net",
 			Hostname:      "A",
@@ -344,7 +346,7 @@ func (suite *ReconcilerSuite) TestUpdateSecretDevice() {
 
 	// Check the device secret.
 	var secret corev1.Secret
-	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}, &secret)
+	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}, &secret)
 	suite.Require().NoError(err)
 
 	// Note: The existing annotation and label are preserved if they are not one of the device metadata.
@@ -372,7 +374,7 @@ func (suite *ReconcilerSuite) TestDeleteSecretDevice() {
 	err := suite.kubernetesMock.Create(context.TODO(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "A.fake.ts.net",
-			Namespace: "default",
+			Namespace: "argocd",
 			Annotations: map[string]string{
 				AnnotationDeviceID: "fake-device-id",
 			},
@@ -381,12 +383,12 @@ func (suite *ReconcilerSuite) TestDeleteSecretDevice() {
 	suite.Require().NoError(err)
 
 	// Delete the device secret.
-	err = suite.reconciler.DeleteDeviceSecret(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"})
+	err = suite.reconciler.DeleteDeviceSecret(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"})
 	suite.Require().NoError(err)
 
 	// Check the device secret.
 	var secret corev1.Secret
-	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "default"}, &secret)
+	err = suite.kubernetesMock.Get(context.TODO(), types.NamespacedName{Name: "A.fake.ts.net", Namespace: "argocd"}, &secret)
 	suite.Error(err)
 	suite.True(errors.IsNotFound(err))
 }
@@ -407,6 +409,8 @@ func (suite *ReconcilerSuite) SetupTest() {
 	suite.kubernetesMock = ks
 	suite.tailscaleMock = func(w http.ResponseWriter, r *http.Request) { suite.Fail("request not mocked") }
 	suite.reconciler = &reconciler{ts: ts, ks: ks, filter: tsutils.FuncTagFilter(func(_ tailscale.Device) bool { return true }), managedBy: managedBy}
+
+	suite.kubernetesMock.Create(context.Background(), &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "argocd"}})
 }
 
 func (suite *ReconcilerSuite) TearDownTest() {


### PR DESCRIPTION
This pull request includes changes to the `internal/reconciler` package, specifically modifying the namespace from "default" to "argocd" for various test cases and the `CreateDeviceSecret` function. Additionally, it includes some comments to ignore specific golangci-lint warnings.

Namespace modifications:

* [`internal/reconciler/reconciler.go`](diffhunk://#diff-c2f937070d34d445f6561593d81e9d24a97de76a1b7ad8e518724478484ab00cL151-R152): Updated `CreateDeviceSecret` function to use `namespacedName.Namespace` instead of hardcoded "default" namespace.
* [`internal/reconciler/reconciler_test.go`](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL58-R67): Updated multiple test cases to use the "argocd" namespace instead of "default". [[1]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL58-R67) [[2]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL87-R89) [[3]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL125-R134) [[4]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL154-R156) [[5]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL187-R196) [[6]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL222-R224) [[7]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL239-R248) [[8]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL263-R272) [[9]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL279-R281) [[10]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL293-R295) [[11]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL315-R317) [[12]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL333-R335) [[13]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL347-R349) [[14]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL375-R377) [[15]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdL384-R391) [[16]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR412-R413)

Linting comments:

* [`internal/reconciler/reconciler_test.go`](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR1-R2): Added comments to ignore specific golangci-lint warnings.