### PR TITLE
:sparkles:: Add Kubernetes probes

### DIFF
--- a/deploy/manifests/default/argotails.deployment.yaml
+++ b/deploy/manifests/default/argotails.deployment.yaml
@@ -2,8 +2,6 @@
 # trunk-ignore-all(checkov/CKV_K8S_38): This is required for Argotails as it is a Kubernetes controller
 # trunk-ignore-all(checkov/CKV_K8S_43,checkov/CKV_K8S_14): The image is managed by Kustomize and the kustomization.yaml
 # trunk-ignore-all(checkov/CKV2_K8S_6): Network policies must be defined by the end-user as they are specific to the environment
-
-# trunk-ignore-all(checkov/CKV_K8S_8,checkov/CKV_K8S_9): Liveness and readiness probes are not yet implemented in Argotails [TODO]
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -34,31 +32,40 @@ spec:
               value: example.ts.net # NOTE: this is a placeholder, replace with your Tailscale tailnet
           image: ghcr.io/chezmoi-sh/argotails:latest
           imagePullPolicy: Always
-          # TODO: readiness/liveness probes are not yet implemented in Argotails
-          # livenessProbe:
-          #   failureThreshold: 3
-          #   httpGet:
-          #     path: /livez
-          #     port: 8080
-          #     scheme: HTTP
-          #   initialDelaySeconds: 5
-          #   periodSeconds: 10
-          #   timeoutSeconds: 1
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            timeoutSeconds: 1
           name: argotails
           ports:
             - containerPort: 8080
               name: metrics
               protocol: TCP
-          # TODO: readiness/liveness probes are not yet implemented in Argotails
-          # readinessProbe:
-          #   failureThreshold: 3
-          #   httpGet:
-          #     path: /readyz
-          #     port: 8080
-          #     scheme: HTTP
-          #   initialDelaySeconds: 5
-          #   periodSeconds: 10
-          #   timeoutSeconds: 1
+            - containerPort: 8081
+              name: health
+              protocol: TCP
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: 8081
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 1
+          startupProbe:
+            failureThreshold: 30
+            httpGet:
+              path: /readyz
+              port: 8081
+              scheme: HTTP
+            periodSeconds: 3
+            timeoutSeconds: 1
           resources:
             limits:
               cpu: 500m
@@ -103,6 +110,10 @@ spec:
       protocol: TCP
       targetPort: 8080
       appProtocol: prometheus
+    - name: health
+      port: 8081
+      protocol: TCP
+      targetPort: 8081
   selector:
     app.kubernetes.io/instance: argotails-controller
   type: ClusterIP


### PR DESCRIPTION
This pull request includes significant updates to the `argotails` deployment configuration and the controller to enhance health monitoring capabilities. The most important changes are the implementation of liveness, readiness, and startup probes, as well as the addition of health check endpoints.

Enhancements to health monitoring:

* [`deploy/manifests/default/argotails.deployment.yaml`](diffhunk://#diff-4396fa46b0887e62d089d626a82619132f9de508cc520e60b76c81f1c2b36d7cL37-R68): Implemented liveness, readiness, and startup probes to ensure the application is running correctly and can recover from failures. Updated container ports to include a health check port. [[1]](diffhunk://#diff-4396fa46b0887e62d089d626a82619132f9de508cc520e60b76c81f1c2b36d7cL37-R68) [[2]](diffhunk://#diff-4396fa46b0887e62d089d626a82619132f9de508cc520e60b76c81f1c2b36d7cR113-R116)
* [`internal/controller/controller.go`](diffhunk://#diff-0f9820b6474392a34affebf1482afae577d622a0e11e0b0ac92a2e1930224b79R28): Added health check endpoints for liveness and readiness using the `controller-runtime` healthz package. Configured the controller manager to expose these endpoints. [[1]](diffhunk://#diff-0f9820b6474392a34affebf1482afae577d622a0e11e0b0ac92a2e1930224b79R28) [[2]](diffhunk://#diff-0f9820b6474392a34affebf1482afae577d622a0e11e0b0ac92a2e1930224b79R150-R168)