### PR TITLE
:sparkles:: Add device IP address in annotation

### DIFF
--- a/.github/workflows/merge_group,pull_request.go.yaml
+++ b/.github/workflows/merge_group,pull_request.go.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        go: [1.23]
+        go: [1.24]
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: 🚧 Setup Golang ${{ matrix.go }}

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@
 # To learn more about the format of this file, see https://docs.trunk.io/reference/trunk-yaml
 version: 0.1
 cli:
-  version: 1.22.11
+  version: 1.22.12
 # Trunk provides extensibility via plugins. (https://docs.trunk.io/plugins)
 plugins:
   sources:
@@ -12,16 +12,17 @@ plugins:
 # Many linters and tools depend on runtimes - configure them here. (https://docs.trunk.io/runtimes)
 runtimes:
   enabled:
-    - go@1.21.0
+    - go@1.24.0
     - node@18.20.5
     - python@3.10.8
     - rust@1.82.0
 # This is the section where you manage your linters. (https://docs.trunk.io/check/configuration)
 lint:
   enabled:
+    - renovate@39.234.0
     - actionlint@1.7.7
-    - osv-scanner@2.0.0
-    - checkov@3.2.392
+    - osv-scanner@2.0.1
+    - checkov@3.2.399
     - git-diff-check
     - gofmt@1.20.4
     - golangci-lint@1.64.8
@@ -31,7 +32,7 @@ lint:
     - prettier@3.5.3
     - shellcheck@0.10.0
     - shfmt@3.6.0
-    - trufflehog@3.88.18
+    - trufflehog@3.88.23
     - yamllint@1.37.0
 actions:
   enabled:

--- a/internal/reconciler/reconciler.go
+++ b/internal/reconciler/reconciler.go
@@ -22,6 +22,8 @@ import (
 const (
 	// AnnotationDeviceID is the annotation key for the device ID.
 	AnnotationDeviceID = "device.tailscale.com/id"
+	// AnnotationDeviceAddress is the annotation key for the device address.
+	AnnotationDeviceAddress = "device.tailscale.com/address"
 	// AnnotationDeviceHostname is the annotation key for the device hostname.
 	AnnotationDeviceHostname = "device.tailscale.com/hostname"
 	// AnnotationDeviceTailnet is the annotation key for the device name.
@@ -152,6 +154,7 @@ func (r reconciler) CreateDeviceSecret(ctx context.Context, namespacedName types
 			Namespace: namespacedName.Namespace,
 			Annotations: map[string]string{
 				AnnotationDeviceID:       device.NodeID,
+				AnnotationDeviceAddress:  device.Addresses[0],
 				AnnotationDeviceHostname: device.Hostname,
 			},
 			Labels: map[string]string{
@@ -196,6 +199,7 @@ func (r reconciler) UpdateDeviceSecret(ctx context.Context, namespacedName types
 	// Update secret metadata
 	secret.Annotations[AnnotationDeviceID] = device.NodeID
 	secret.Annotations[AnnotationDeviceHostname] = device.Hostname
+	secret.Annotations[AnnotationDeviceAddress] = device.Addresses[0]
 	secret.Labels["argocd.argoproj.io/secret-type"] = "cluster"
 	secret.Labels["apps.kubernetes.io/managed-by"] = r.managedBy
 	secret.Labels[LabelDeviceOS] = device.OS

--- a/internal/reconciler/reconciler_test.go
+++ b/internal/reconciler/reconciler_test.go
@@ -45,6 +45,7 @@ func (suite *ReconcilerSuite) TestReconcile_NewDevice() {
 					Name:          "A.fake.ts.net",
 					Hostname:      "A",
 					NodeID:        "fake-device-id",
+					Addresses:     []string{"0.0.0.0"},
 					OS:            "linux",
 					ClientVersion: "v1.2.3",
 					Tags:          []string{"tag:tag1", "tag:tag2"},
@@ -70,6 +71,7 @@ func (suite *ReconcilerSuite) TestReconcile_NewDevice() {
 	suite.Equal("fake-device-id", secret.Annotations[AnnotationDeviceID])
 	suite.Equal("A", secret.Annotations[AnnotationDeviceHostname])
 	suite.Equal("fake.ts.net", secret.Annotations[AnnotationDeviceTailnet])
+	suite.Equal("0.0.0.0", secret.Annotations[AnnotationDeviceAddress])
 	suite.Equal("cluster", secret.Labels["argocd.argoproj.io/secret-type"])
 	suite.Equal(managedBy, secret.Labels["apps.kubernetes.io/managed-by"])
 	suite.Equal("linux", secret.Labels[LabelDeviceOS])
@@ -91,6 +93,7 @@ func (suite *ReconcilerSuite) TestReconcile_ExistingDevice() {
 				AnnotationDeviceID:       "fake-device-id",
 				AnnotationDeviceHostname: "A",
 				AnnotationDeviceTailnet:  "fake.ts.net",
+				AnnotationDeviceAddress:  "0.0.0.0",
 			},
 			Labels: map[string]string{
 				"argocd.argoproj.io/secret-type": "cluster",
@@ -112,6 +115,7 @@ func (suite *ReconcilerSuite) TestReconcile_ExistingDevice() {
 					Name:          "A.fake.ts.net",
 					Hostname:      "A",
 					NodeID:        "fake-device-id",
+					Addresses:     []string{"0.0.0.0"},
 					OS:            "linux",
 					ClientVersion: "v1.2.3",
 					Tags:          []string{"tag:tag1", "tag:tag2"},
@@ -137,6 +141,7 @@ func (suite *ReconcilerSuite) TestReconcile_ExistingDevice() {
 	suite.Equal("fake-device-id", secret.Annotations[AnnotationDeviceID])
 	suite.Equal("A", secret.Annotations[AnnotationDeviceHostname])
 	suite.Equal("fake.ts.net", secret.Annotations[AnnotationDeviceTailnet])
+	suite.Equal("0.0.0.0", secret.Annotations[AnnotationDeviceAddress])
 	suite.Equal("cluster", secret.Labels["argocd.argoproj.io/secret-type"])
 	suite.Equal(managedBy, secret.Labels["apps.kubernetes.io/managed-by"])
 	suite.Equal("linux", secret.Labels[LabelDeviceOS])
@@ -174,6 +179,7 @@ func (suite *ReconcilerSuite) TestReconcile_UpdatedExistingDevice() {
 					Name:          "A.fake.ts.net",
 					Hostname:      "A",
 					NodeID:        "fake-device-id",
+					Addresses:     []string{"0.0.0.0"},
 					OS:            "linux",
 					ClientVersion: "v1.2.3",
 					Tags:          []string{"tag:tag1", "tag:tag2"},
@@ -205,6 +211,7 @@ func (suite *ReconcilerSuite) TestReconcile_UpdatedExistingDevice() {
 	suite.Equal("fake-device-id", secret.Annotations[AnnotationDeviceID])
 	suite.Equal("A", secret.Annotations[AnnotationDeviceHostname])
 	suite.Equal("fake.ts.net", secret.Annotations[AnnotationDeviceTailnet])
+	suite.Equal("0.0.0.0", secret.Annotations[AnnotationDeviceAddress])
 	suite.Equal("cluster", secret.Labels["argocd.argoproj.io/secret-type"])
 	suite.Equal(managedBy, secret.Labels["apps.kubernetes.io/managed-by"])
 	suite.Equal("linux", secret.Labels[LabelDeviceOS])
@@ -283,6 +290,7 @@ func (suite *ReconcilerSuite) TestCreateSecretDevice() {
 			Name:          "A.fake.ts.net",
 			Hostname:      "A",
 			NodeID:        "fake-device-id",
+			Addresses:     []string{"0.0.0.0"},
 			OS:            "linux",
 			ClientVersion: "v1.2.3",
 			Tags:          []string{"tag:tag1", "tag:tag2"},
@@ -298,6 +306,7 @@ func (suite *ReconcilerSuite) TestCreateSecretDevice() {
 	suite.Equal("fake-device-id", secret.Annotations[AnnotationDeviceID])
 	suite.Equal("A", secret.Annotations[AnnotationDeviceHostname])
 	suite.Equal("fake.ts.net", secret.Annotations[AnnotationDeviceTailnet])
+	suite.Equal("0.0.0.0", secret.Annotations[AnnotationDeviceAddress])
 	suite.Equal("cluster", secret.Labels["argocd.argoproj.io/secret-type"])
 	suite.Equal(managedBy, secret.Labels["apps.kubernetes.io/managed-by"])
 	suite.Equal("linux", secret.Labels[LabelDeviceOS])
@@ -337,6 +346,7 @@ func (suite *ReconcilerSuite) TestUpdateSecretDevice() {
 			Name:          "A.fake.ts.net",
 			Hostname:      "A",
 			NodeID:        "fake-device-id",
+			Addresses:     []string{"0.0.0.0"},
 			OS:            "linux",
 			ClientVersion: "v1.2.3",
 			Tags:          []string{"tag:tag1", "tag:tag2"},
@@ -358,6 +368,7 @@ func (suite *ReconcilerSuite) TestUpdateSecretDevice() {
 	suite.Equal("fake-device-id", secret.Annotations[AnnotationDeviceID])
 	suite.Equal("A", secret.Annotations[AnnotationDeviceHostname])
 	suite.Equal("fake.ts.net", secret.Annotations[AnnotationDeviceTailnet])
+	suite.Equal("0.0.0.0", secret.Annotations[AnnotationDeviceAddress])
 	suite.Equal("cluster", secret.Labels["argocd.argoproj.io/secret-type"])
 	suite.Equal(managedBy, secret.Labels["apps.kubernetes.io/managed-by"])
 	suite.Equal("linux", secret.Labels[LabelDeviceOS])


### PR DESCRIPTION
This pull request adds support for annotating devices with their addresses in the reconciler. It includes changes to both the main reconciler code and the associated tests.

### Main Code Changes:

* Added `AnnotationDeviceAddress` constant to store the device address annotation key in `internal/reconciler/reconciler.go`.
* Updated the `CreateDeviceSecret` and `UpdateDeviceSecret` methods to include the device address in the annotations. [[1]](diffhunk://#diff-c2f937070d34d445f6561593d81e9d24a97de76a1b7ad8e518724478484ab00cR157) [[2]](diffhunk://#diff-c2f937070d34d445f6561593d81e9d24a97de76a1b7ad8e518724478484ab00cR202)

### Test Code Changes:

* Modified the `TestReconcile_NewDevice`, `TestReconcile_ExistingDevice`, `TestReconcile_UpdatedExistingDevice`, `TestCreateSecretDevice`, and `TestUpdateSecretDevice` test functions to include the device address in the annotations and device mock data in `internal/reconciler/reconciler_test.go`. [[1]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR48) [[2]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR74) [[3]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR96) [[4]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR118) [[5]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR144) [[6]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR182) [[7]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR214) [[8]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR293) [[9]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR309) [[10]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR349) [[11]](diffhunk://#diff-7a76e5a69fb82a6d94aaf647c3f23dccb53e04c8264f9f5b978f93d565ad22bdR371)